### PR TITLE
Code clean-up and refactoring for enums used as query parameters

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,10 +10,6 @@ repositories {
     mavenCentral()
 }
 
-object Versions {
-    const val ktorVersion = "2.0.2"
-}
-
 dependencies {
     testImplementation(kotlin("test"))
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     kotlin("jvm") version "1.7.0"
     application
@@ -23,10 +21,20 @@ dependencies {
     implementation("io.ktor:ktor-client-okhttp:${Versions.ktorVersion}")
 }
 
-tasks.test {
-    useJUnitPlatform()
-}
+tasks {
+    compileKotlin {
+        kotlinOptions {
+            jvmTarget = "1.8"
+        }
+    }
 
-tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    compileTestKotlin {
+        kotlinOptions {
+            jvmTarget = "1.8"
+        }
+    }
+
+    test {
+        useJUnitPlatform()
+    }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,0 +1,3 @@
+object Versions {
+    const val ktorVersion = "2.0.2"
+}

--- a/src/main/kotlin/se/vallett/kdex/api/NamedSerializableValue.kt
+++ b/src/main/kotlin/se/vallett/kdex/api/NamedSerializableValue.kt
@@ -1,0 +1,5 @@
+package se.vallett.kdex.api
+
+interface NamedSerializableValue {
+    val serializedName: String
+}

--- a/src/main/kotlin/se/vallett/kdex/api/client/KDexClient.kt
+++ b/src/main/kotlin/se/vallett/kdex/api/client/KDexClient.kt
@@ -3,7 +3,7 @@ package se.vallett.kdex.api.client
 import io.ktor.client.HttpClient
 
 object KDexClient : IKDexClient {
-    val client : HttpClient = HttpClient()
+    val client: HttpClient = HttpClient()
 
     /**
      * Creates a builder for a Search Manga request

--- a/src/main/kotlin/se/vallett/kdex/api/client/KDexClient.kt
+++ b/src/main/kotlin/se/vallett/kdex/api/client/KDexClient.kt
@@ -11,5 +11,6 @@ object KDexClient : IKDexClient {
      * See [Get search manga](https://api.mangadex.org/swagger.html#/Manga/get-search-manga)
      */
     override fun searchManga() {
+        TODO("create builder")
     }
 }

--- a/src/main/kotlin/se/vallett/kdex/api/client/requests/DefaultRequest.kt
+++ b/src/main/kotlin/se/vallett/kdex/api/client/requests/DefaultRequest.kt
@@ -5,17 +5,11 @@ abstract class DefaultRequest(private val parameters : List<Pair<String, String>
     abstract val defaultEndpoint : String
 
     //TODO add configured URL
-    fun getRequest() : String {
-        return "https://api.mangadex.org/$defaultEndpoint${buildParameters()}"
-    }
+    fun getRequest() : String = "https://api.mangadex.org/$defaultEndpoint${buildParameters()}"
 
-    private fun buildParameters() : String {
-        return "?${generateParams()}"
-    }
+    private fun buildParameters() : String = "?${generateParams()}"
 
-    private fun generateParams() : String {
-        return parameters.joinToString("&") { (header, value) -> "$header=$value" }
-    }
+    private fun generateParams() : String = parameters.joinToString("&") { (header, value) -> "$header=$value" }
 
     abstract class DefaultBuilder<out T : DefaultRequest> {
         protected val queryParams : ArrayList<Pair<String, String>> = ArrayList()

--- a/src/main/kotlin/se/vallett/kdex/api/client/requests/DefaultRequest.kt
+++ b/src/main/kotlin/se/vallett/kdex/api/client/requests/DefaultRequest.kt
@@ -13,7 +13,7 @@ abstract class DefaultRequest(private val parameters: List<Pair<String, String>>
     private fun generateParams(): String = parameters.joinToString("&") { (header, value) -> "$header=$value" }
 
     abstract class DefaultBuilder<out T : DefaultRequest> {
-        protected val queryParams: ArrayList<Pair<String, String>> = ArrayList()
+        protected val queryParams: MutableList<Pair<String, String>> = ArrayList()
 
         protected fun addQueryParam(param: String, value: String) {
             queryParams.add(Pair(param, value))

--- a/src/main/kotlin/se/vallett/kdex/api/client/requests/DefaultRequest.kt
+++ b/src/main/kotlin/se/vallett/kdex/api/client/requests/DefaultRequest.kt
@@ -4,13 +4,13 @@ abstract class DefaultRequest(private val parameters : List<Pair<String, String>
 
     abstract val defaultEndpoint : String
 
+    //TODO add configured URL
     fun getRequest() : String {
-        //TODO add configured URL
-        return "https://api.mangadex.org/" + defaultEndpoint + buildParameters()
+        return "https://api.mangadex.org/$defaultEndpoint${buildParameters()}"
     }
 
     private fun buildParameters() : String {
-        return "?" + generateParams()
+        return "?${generateParams()}"
     }
 
     private fun generateParams() : String {

--- a/src/main/kotlin/se/vallett/kdex/api/client/requests/DefaultRequest.kt
+++ b/src/main/kotlin/se/vallett/kdex/api/client/requests/DefaultRequest.kt
@@ -34,7 +34,7 @@ abstract class DefaultRequest(private val parameters: List<Pair<String, String>>
             queryParams.add(Pair(param, value.serializedName))
         }
 
-        protected fun addQueryParam(param: String, values: Iterable<*>) {
+        protected fun addQueryParam(param: String, values: Iterable<Any>) {
             values.forEach { value ->
                 val serializedValue = if (value is NamedSerializableValue) value.serializedName else value.toString()
                 queryParams.add(Pair("$param[]", serializedValue))

--- a/src/main/kotlin/se/vallett/kdex/api/client/requests/DefaultRequest.kt
+++ b/src/main/kotlin/se/vallett/kdex/api/client/requests/DefaultRequest.kt
@@ -1,5 +1,7 @@
 package se.vallett.kdex.api.client.requests
 
+import se.vallett.kdex.api.NamedSerializableValue
+
 abstract class DefaultRequest(private val parameters: List<Pair<String, String>>) {
     abstract val defaultEndpoint: String
 
@@ -25,8 +27,18 @@ abstract class DefaultRequest(private val parameters: List<Pair<String, String>>
             queryParams.add(Pair(param, value.name))
         }
 
+        @JvmName("addQueryParamSerializedName")
+        protected fun <T> addQueryParam(param: String, value: T)
+                where T : Enum<T>,
+                      T : NamedSerializableValue {
+            queryParams.add(Pair(param, value.serializedName))
+        }
+
         protected fun addQueryParam(param: String, values: Iterable<*>) {
-            values.forEach { value -> queryParams.add(Pair("$param[]", value.toString())) }
+            values.forEach { value ->
+                val serializedValue = if (value is NamedSerializableValue) value.serializedName else value.toString()
+                queryParams.add(Pair("$param[]", serializedValue))
+            }
         }
 
         abstract fun build(): T

--- a/src/main/kotlin/se/vallett/kdex/api/client/requests/DefaultRequest.kt
+++ b/src/main/kotlin/se/vallett/kdex/api/client/requests/DefaultRequest.kt
@@ -1,33 +1,34 @@
 package se.vallett.kdex.api.client.requests
 
-abstract class DefaultRequest(private val parameters : List<Pair<String, String>> ) {
-
-    abstract val defaultEndpoint : String
+abstract class DefaultRequest(private val parameters: List<Pair<String, String>>) {
+    abstract val defaultEndpoint: String
 
     //TODO add configured URL
-    fun getRequest() : String = "https://api.mangadex.org/$defaultEndpoint${buildParameters()}"
+    fun getRequest(): String = "https://api.mangadex.org/$defaultEndpoint${buildParameters()}"
 
-    private fun buildParameters() : String = "?${generateParams()}"
+    private fun buildParameters(): String = "?${generateParams()}"
 
-    private fun generateParams() : String = parameters.joinToString("&") { (header, value) -> "$header=$value" }
+    private fun generateParams(): String = parameters.joinToString("&") { (header, value) -> "$header=$value" }
 
     abstract class DefaultBuilder<out T : DefaultRequest> {
-        protected val queryParams : ArrayList<Pair<String, String>> = ArrayList()
+        protected val queryParams: ArrayList<Pair<String, String>> = ArrayList()
 
-        protected fun addQueryParam(param : String, value : String) {
+        protected fun addQueryParam(param: String, value: String) {
             queryParams.add(Pair(param, value))
         }
 
-        protected fun addQueryParam(param : String, value : Any) {
+        protected fun addQueryParam(param: String, value: Any) {
             queryParams.add(Pair(param, value.toString()))
         }
 
-        protected fun addQueryParam(param : String, value : Enum<*>) { queryParams.add(Pair(param, value.name)) }
-
-        protected fun addQueryParam(param : String, values : Iterable<*>) {
-            values.forEach{value -> queryParams.add(Pair("$param[]", value.toString())) }
+        protected fun addQueryParam(param: String, value: Enum<*>) {
+            queryParams.add(Pair(param, value.name))
         }
 
-        abstract fun build() : T
+        protected fun addQueryParam(param: String, values: Iterable<*>) {
+            values.forEach { value -> queryParams.add(Pair("$param[]", value.toString())) }
+        }
+
+        abstract fun build(): T
     }
 }

--- a/src/main/kotlin/se/vallett/kdex/api/manga/list/MangaList.kt
+++ b/src/main/kotlin/se/vallett/kdex/api/manga/list/MangaList.kt
@@ -35,8 +35,6 @@ class MangaList(queryParams: List<Pair<String, String>>) : DefaultRequest(queryP
         fun title(title: String) = apply { addQueryParam("title", title) }
         fun updatedAtSince(updatedAtSince: String) = apply { addQueryParam("updatedAtSince", updatedAtSince) }
         fun year(year: Int) = apply { addQueryParam("year", year) }
-        override fun build(): MangaList {
-            return MangaList(queryParams)
-        }
+        override fun build(): MangaList = MangaList(queryParams)
     }
 }

--- a/src/main/kotlin/se/vallett/kdex/api/manga/list/MangaList.kt
+++ b/src/main/kotlin/se/vallett/kdex/api/manga/list/MangaList.kt
@@ -1,40 +1,65 @@
 package se.vallett.kdex.api.manga.list
 
 import se.vallett.kdex.api.client.requests.DefaultRequest
-import se.vallett.kdex.api.manga.list.paramvalues.ExcludedTagsMode
-import se.vallett.kdex.api.manga.list.paramvalues.IncludedTagsMode
-import se.vallett.kdex.api.manga.list.paramvalues.MangaContentRating
-import se.vallett.kdex.api.manga.list.paramvalues.MangaPublicationDemographic
-import se.vallett.kdex.api.manga.list.paramvalues.MangaStatus
+import se.vallett.kdex.api.manga.list.paramvalues.*
 
 class MangaList(queryParams: List<Pair<String, String>>) : DefaultRequest(queryParams) {
-
     override val defaultEndpoint: String
         get() = "manga"
 
     class Builder : DefaultBuilder<MangaList>() {
-        fun artists(artists : Iterable<String>) = apply { addQueryParam("artists", artists) }
-        fun authors(authors : Iterable<String>) = apply { addQueryParam("authors", authors) }
-        fun availableTranslatedLanguage(availableTranslatedLanguage: Iterable<String>) = apply { addQueryParam("availableTranslatedLanguage", availableTranslatedLanguage) }
-        fun contentRating(contentRating: Iterable<MangaContentRating>) = apply { addQueryParam("contentRating", contentRating) }
+        fun artists(artists: Iterable<String>) = apply { addQueryParam("artists", artists) }
+
+        fun authors(authors: Iterable<String>) = apply { addQueryParam("authors", authors) }
+
+        fun availableTranslatedLanguage(availableTranslatedLanguage: Iterable<String>) =
+            apply { addQueryParam("availableTranslatedLanguage", availableTranslatedLanguage) }
+
+        fun contentRating(contentRating: Iterable<MangaContentRating>) =
+            apply { addQueryParam("contentRating", contentRating) }
+
         fun createdAtSince(createdAtSince: String) = apply { addQueryParam("createdAtSince", createdAtSince) }
-        fun excludedOriginalLanguage(excludedOriginalLanguage: Iterable<String>) = apply { addQueryParam("excludedOriginalLanguage", excludedOriginalLanguage) }
+
+        fun excludedOriginalLanguage(excludedOriginalLanguage: Iterable<String>) =
+            apply { addQueryParam("excludedOriginalLanguage", excludedOriginalLanguage) }
+
         fun excludedTags(excludedTags: Iterable<String>) = apply { addQueryParam("excludedTags", excludedTags) }
-        fun excludedTagsMode(excludedTagsMode: ExcludedTagsMode) = apply { addQueryParam("excludedTagsMode", excludedTagsMode) }
+
+        fun excludedTagsMode(excludedTagsMode: ExcludedTagsMode) =
+            apply { addQueryParam("excludedTagsMode", excludedTagsMode) }
+
         fun includedTags(includedTags: Iterable<String>) = apply { addQueryParam("includedTags", includedTags) }
-        fun includedTagsMode(includedTagsMode: IncludedTagsMode) = apply { addQueryParam("includedTagsMode", includedTagsMode) }
+
+        fun includedTagsMode(includedTagsMode: IncludedTagsMode) =
+            apply { addQueryParam("includedTagsMode", includedTagsMode) }
+
         fun includes(includes: Iterable<String>) = apply { addQueryParam("includes", includes) }
+
         fun group(group: String) = apply { addQueryParam("group", group) }
-        fun hasAvailableChapters(hasAvailableChapters: Boolean) = apply { addQueryParam("hasAvailableChapters", hasAvailableChapters) }
+
+        fun hasAvailableChapters(hasAvailableChapters: Boolean) =
+            apply { addQueryParam("hasAvailableChapters", hasAvailableChapters) }
+
         fun ids(ids: Iterable<String>) = apply { addQueryParam("ids", ids) }
+
         fun limit(limit: Int) = apply { addQueryParam("limit", limit) }
+
         fun offset(offset: Int) = apply { addQueryParam("offset", offset) }
-        fun originalLanguage(originalLanguage: Iterable<String>) = apply { addQueryParam("originalLanguage", originalLanguage) }
-        fun publicationDemographic(mangaPublicationDemographic: Iterable<MangaPublicationDemographic>) = apply { addQueryParam("publicationDemographic", mangaPublicationDemographic) }
+
+        fun originalLanguage(originalLanguage: Iterable<String>) =
+            apply { addQueryParam("originalLanguage", originalLanguage) }
+
+        fun publicationDemographic(mangaPublicationDemographic: Iterable<MangaPublicationDemographic>) =
+            apply { addQueryParam("publicationDemographic", mangaPublicationDemographic) }
+
         fun status(status: Iterable<MangaStatus>) = apply { addQueryParam("status", status) }
+
         fun title(title: String) = apply { addQueryParam("title", title) }
+
         fun updatedAtSince(updatedAtSince: String) = apply { addQueryParam("updatedAtSince", updatedAtSince) }
+
         fun year(year: Int) = apply { addQueryParam("year", year) }
+
         override fun build(): MangaList = MangaList(queryParams)
     }
 }

--- a/src/main/kotlin/se/vallett/kdex/api/manga/list/paramvalues/MangaContentRating.kt
+++ b/src/main/kotlin/se/vallett/kdex/api/manga/list/paramvalues/MangaContentRating.kt
@@ -6,5 +6,5 @@ enum class MangaContentRating {
     safe,
     suggestive,
     erotica,
-    pornographic
+    pornographic,
 }

--- a/src/main/kotlin/se/vallett/kdex/api/manga/list/paramvalues/MangaContentRating.kt
+++ b/src/main/kotlin/se/vallett/kdex/api/manga/list/paramvalues/MangaContentRating.kt
@@ -1,10 +1,12 @@
-@file:Suppress("EnumEntryName")
-
 package se.vallett.kdex.api.manga.list.paramvalues
 
-enum class MangaContentRating {
-    safe,
-    suggestive,
-    erotica,
-    pornographic,
+import se.vallett.kdex.api.NamedSerializableValue
+
+enum class MangaContentRating : NamedSerializableValue {
+    SAFE,
+    SUGGESTIVE,
+    EROTICA,
+    PORNOGRAPHIC;
+
+    override val serializedName: String = name.lowercase()
 }

--- a/src/main/kotlin/se/vallett/kdex/api/manga/list/paramvalues/MangaPublicationDemographic.kt
+++ b/src/main/kotlin/se/vallett/kdex/api/manga/list/paramvalues/MangaPublicationDemographic.kt
@@ -7,5 +7,5 @@ enum class MangaPublicationDemographic {
     shoujo,
     josei,
     seinen,
-    none
+    none,
 }

--- a/src/main/kotlin/se/vallett/kdex/api/manga/list/paramvalues/MangaPublicationDemographic.kt
+++ b/src/main/kotlin/se/vallett/kdex/api/manga/list/paramvalues/MangaPublicationDemographic.kt
@@ -1,11 +1,13 @@
-@file:Suppress("EnumEntryName")
-
 package se.vallett.kdex.api.manga.list.paramvalues
 
-enum class MangaPublicationDemographic {
-    shounen,
-    shoujo,
-    josei,
-    seinen,
-    none,
+import se.vallett.kdex.api.NamedSerializableValue
+
+enum class MangaPublicationDemographic : NamedSerializableValue {
+    SHOUNEN,
+    SHOUJO,
+    JOSEI,
+    SEINEN,
+    NONE;
+
+    override val serializedName: String = name.lowercase()
 }

--- a/src/main/kotlin/se/vallett/kdex/api/manga/list/paramvalues/MangaStatus.kt
+++ b/src/main/kotlin/se/vallett/kdex/api/manga/list/paramvalues/MangaStatus.kt
@@ -1,10 +1,12 @@
-@file:Suppress("EnumEntryName") //As the values are defined lowercase in the API
-
 package se.vallett.kdex.api.manga.list.paramvalues
 
-enum class MangaStatus {
-    ongoing,
-    completed,
-    hiatus,
-    cancelled,
+import se.vallett.kdex.api.NamedSerializableValue
+
+enum class MangaStatus : NamedSerializableValue {
+    ONGOING,
+    COMPLETED,
+    HIATUS,
+    CANCELLED;
+
+    override val serializedName: String = name.lowercase()
 }

--- a/src/test/kotlin/se/vallett/kdex/api/manga/list/MangaListRequestTest.kt
+++ b/src/test/kotlin/se/vallett/kdex/api/manga/list/MangaListRequestTest.kt
@@ -104,7 +104,7 @@ internal class MangaListRequestTest {
     fun testStatus() {
         val builder = MangaList.Builder()
 
-        val request = builder.status(listOf(MangaStatus.cancelled, MangaStatus.hiatus)).build().getRequest()
+        val request = builder.status(listOf(MangaStatus.CANCELLED, MangaStatus.HIATUS)).build().getRequest()
 
         assertEquals("https://api.mangadex.org/manga?status[]=cancelled&status[]=hiatus", request)
     }
@@ -140,7 +140,7 @@ internal class MangaListRequestTest {
     fun testPublicationDemographic() {
         val builder = MangaList.Builder()
 
-        val request = builder.publicationDemographic(listOf(MangaPublicationDemographic.shoujo, MangaPublicationDemographic.josei)).build().getRequest()
+        val request = builder.publicationDemographic(listOf(MangaPublicationDemographic.SHOUJO, MangaPublicationDemographic.JOSEI)).build().getRequest()
 
         assertEquals("https://api.mangadex.org/manga?publicationDemographic[]=shoujo&publicationDemographic[]=josei", request)
     }
@@ -160,7 +160,7 @@ internal class MangaListRequestTest {
         val builder = MangaList.Builder()
 
         //Very suitable ratings
-        val request = builder.contentRating(listOf(MangaContentRating.erotica, MangaContentRating.safe)).build().getRequest()
+        val request = builder.contentRating(listOf(MangaContentRating.EROTICA, MangaContentRating.SAFE)).build().getRequest()
 
         assertEquals("https://api.mangadex.org/manga?contentRating[]=erotica&contentRating[]=safe", request)
     }


### PR DESCRIPTION
Outside of the commits, there's a few things to note.

In `se.vallett.kdex.api.client.KDexClient` you're storing a `HttpClient`:
`HttpClient` in ktor is `Closeable` and will *need* to be closed to release it's resources at some point, or it will keep a program running.
`KDexClient` could be made `Closeable` itself, but seeing as it's implemented as `object` currently, that might not make too much sense, as then we'd be closing and essentially making a global variable useless. 
It's probably smartest to either turn `KDexClient` into a class and require it to be closed manually by the user, or not store a global client, and just create new ones as required and close those when done.
First approach creates the least amount of garbage at runtime, but adds more mental overhead for the user, while the second approach is basically invisible to the user, but can end up creating a lot of garbage.

Regarding `se.vallett.kdex.api.client.requests.DefaultRequest` and the `DefaultBuilder`:
Ktor comes with its own `Url` class, and with that, a builder for it, [some examples can be seen here](https://stackoverflow.com/a/64432035).
Along with that, it also comes with it's own `Parameters` type, and a builder for it.
So rather than the current structure, we could probably delegate a lot of grunt work to the facilities provided by Ktor, I'll open a separate PR for this, as this PR is mainly just about cleaning up the code, and not reworking the entire structure used.