### PR TITLE
Use kotest assertions for tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,8 +13,8 @@ repositories {
 dependencies {
     testImplementation(kotlin("test"))
 
-    implementation("io.ktor:ktor-client-core:${Versions.ktorVersion}")
-    implementation("io.ktor:ktor-client-okhttp:${Versions.ktorVersion}")
+    implementation("io.ktor:ktor-client-core:${Versions.ktor}")
+    implementation("io.ktor:ktor-client-okhttp:${Versions.ktor}")
 }
 
 tasks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ repositories {
 
 dependencies {
     testImplementation(kotlin("test"))
+    testImplementation("io.kotest:kotest-assertions-core:${Versions.kotest}")
 
     implementation("io.ktor:ktor-client-core:${Versions.ktor}")
     implementation("io.ktor:ktor-client-okhttp:${Versions.ktor}")

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,3 +1,4 @@
 object Versions {
     const val ktor = "2.0.2"
+    const val kotest = "5.3.0"
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,3 +1,3 @@
 object Versions {
-    const val ktorVersion = "2.0.2"
+    const val ktor = "2.0.2"
 }

--- a/src/test/kotlin/se/vallett/kdex/api/manga/list/MangaListIntegrationTest.kt
+++ b/src/test/kotlin/se/vallett/kdex/api/manga/list/MangaListIntegrationTest.kt
@@ -1,20 +1,17 @@
 package se.vallett.kdex.api.manga.list
 
-import io.ktor.client.HttpClient
+import io.kotest.matchers.booleans.shouldBeTrue
 import io.ktor.http.isSuccess
-import kotlin.test.AfterTest
-import kotlin.test.assertTrue
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import se.vallett.kdex.api.client.KDexClient
 import se.vallett.kdex.api.manga.list.paramvalues.MangaStatus
 import se.vallett.kdex.tags.IntegrationTest
+import kotlin.test.AfterTest
 
 @IntegrationTest
 class MangaListIntegrationTest {
 
-    private val client : KDexClient = KDexClient()
+    private val client: KDexClient = KDexClient()
 
     @AfterTest
     fun closeConnections() {
@@ -23,11 +20,10 @@ class MangaListIntegrationTest {
 
     @Test
     fun testMangaListCall() {
-        val list = MangaList.Builder().limit(1).year(2022).status(listOf( MangaStatus.COMPLETED)).build()
-
+        val list = MangaList.Builder().limit(1).year(2022).status(listOf(MangaStatus.COMPLETED)).build()
         val response = client.searchManga(list)
 
-        assertTrue(response.status.isSuccess())
+        response.status.isSuccess().shouldBeTrue()
     }
 
 }

--- a/src/test/kotlin/se/vallett/kdex/api/manga/list/MangaListRequestTest.kt
+++ b/src/test/kotlin/se/vallett/kdex/api/manga/list/MangaListRequestTest.kt
@@ -1,212 +1,191 @@
 package se.vallett.kdex.api.manga.list
 
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import se.vallett.kdex.api.manga.list.paramvalues.ExcludedTagsMode
-import se.vallett.kdex.api.manga.list.paramvalues.IncludedTagsMode
-import se.vallett.kdex.api.manga.list.paramvalues.MangaContentRating
-import se.vallett.kdex.api.manga.list.paramvalues.MangaPublicationDemographic
-import se.vallett.kdex.api.manga.list.paramvalues.MangaStatus
+import se.vallett.kdex.api.manga.list.paramvalues.*
+import se.vallett.kdex.shouldBeMangaUrl
 
 internal class MangaListRequestTest {
-
     @Test
     fun testArtists() {
         val builder = MangaList.Builder()
-
         val request = builder.artists(listOf("test", "test2")).build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?artists[]=test&artists[]=test2", request)
+        request shouldBeMangaUrl "artists[]=test&artists[]=test2"
     }
 
     @Test
     fun testAuthors() {
         val builder = MangaList.Builder()
-
         val request = builder.authors(listOf("test", "test2")).build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?authors[]=test&authors[]=test2", request)
+        request shouldBeMangaUrl "authors[]=test&authors[]=test2"
     }
 
     @Test
     fun testLimit() {
         val builder = MangaList.Builder()
-
         val request = builder.limit(5).build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?limit=5", request)
+        request shouldBeMangaUrl "limit=5"
     }
 
     @Test
     fun testOffset() {
         val builder = MangaList.Builder()
-
         val request = builder.offset(5).build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?offset=5", request)
+        request shouldBeMangaUrl "offset=5"
     }
 
     @Test
     fun testTitle() {
         val builder = MangaList.Builder()
-
         val request = builder.title("Hakuna mantata").build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?title=Hakuna mantata", request)
+        request shouldBeMangaUrl "title=Hakuna mantata"
     }
 
     @Test
     fun testYear() {
         val builder = MangaList.Builder()
-
         val request = builder.year(2022).build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?year=2022", request)
+        request shouldBeMangaUrl "year=2022"
     }
 
     @Test
     fun testIncludedTags() {
         val builder = MangaList.Builder()
-
         val request = builder.includedTags(listOf("test", "test2")).build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?includedTags[]=test&includedTags[]=test2", request)
+        request shouldBeMangaUrl "includedTags[]=test&includedTags[]=test2"
     }
 
     @Test
     fun testIncludedTagsMode() {
         val builder = MangaList.Builder()
-
         val request = builder.includedTagsMode(IncludedTagsMode.AND).build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?includedTagsMode=AND", request)
+        request shouldBeMangaUrl "includedTagsMode=AND"
     }
 
     @Test
     fun tetExcludedTags() {
         val builder = MangaList.Builder()
-
         val request = builder.excludedTags(listOf("test", "test2")).build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?excludedTags[]=test&excludedTags[]=test2", request)
+        request shouldBeMangaUrl "excludedTags[]=test&excludedTags[]=test2"
     }
 
     @Test
     fun testExcludedTagsMode() {
         val builder = MangaList.Builder()
-
         val request = builder.excludedTagsMode(ExcludedTagsMode.AND).build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?excludedTagsMode=AND", request)
+        request shouldBeMangaUrl "excludedTagsMode=AND"
     }
 
     @Test
     fun testStatus() {
         val builder = MangaList.Builder()
-
         val request = builder.status(listOf(MangaStatus.CANCELLED, MangaStatus.HIATUS)).build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?status[]=cancelled&status[]=hiatus", request)
+        request shouldBeMangaUrl "status[]=cancelled&status[]=hiatus"
     }
 
     @Test
     fun testOriginalLanguage() {
         val builder = MangaList.Builder()
-
         val request = builder.originalLanguage(listOf("Swedish", "Norweigan")).build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?originalLanguage[]=Swedish&originalLanguage[]=Norweigan", request)
+        request shouldBeMangaUrl "originalLanguage[]=Swedish&originalLanguage[]=Norweigan"
     }
 
     @Test
     fun testExcludedOriginalLanguage() {
         val builder = MangaList.Builder()
-
         val request = builder.excludedOriginalLanguage(listOf("Swedish", "Norwegian")).build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?excludedOriginalLanguage[]=Swedish&excludedOriginalLanguage[]=Norwegian", request)
+        request shouldBeMangaUrl "excludedOriginalLanguage[]=Swedish&excludedOriginalLanguage[]=Norwegian"
     }
 
     @Test
     fun testAvailableTranslatedLanguage() {
         val builder = MangaList.Builder()
-
         val request = builder.availableTranslatedLanguage(listOf("Swedish", "Norweigan")).build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?availableTranslatedLanguage[]=Swedish&availableTranslatedLanguage[]=Norweigan", request)
+        request shouldBeMangaUrl "availableTranslatedLanguage[]=Swedish&availableTranslatedLanguage[]=Norweigan"
     }
 
     @Test
     fun testPublicationDemographic() {
         val builder = MangaList.Builder()
+        val request = builder.publicationDemographic(
+            listOf(
+                MangaPublicationDemographic.SHOUJO,
+                MangaPublicationDemographic.JOSEI,
+            )
+        ).build().getRequest()
 
-        val request = builder.publicationDemographic(listOf(MangaPublicationDemographic.SHOUJO, MangaPublicationDemographic.JOSEI)).build().getRequest()
-
-        assertEquals("https://api.mangadex.org/manga?publicationDemographic[]=shoujo&publicationDemographic[]=josei", request)
+        request shouldBeMangaUrl "publicationDemographic[]=shoujo&publicationDemographic[]=josei"
     }
 
 
     @Test
     fun testIds() {
         val builder = MangaList.Builder()
-
         val request = builder.ids(listOf("1231", "2222")).build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?ids[]=1231&ids[]=2222", request)
+        request shouldBeMangaUrl "ids[]=1231&ids[]=2222"
     }
 
     @Test
     fun testContentRating() {
         val builder = MangaList.Builder()
-
         //Very suitable ratings
-        val request = builder.contentRating(listOf(MangaContentRating.EROTICA, MangaContentRating.SAFE)).build().getRequest()
+        val request =
+            builder.contentRating(listOf(MangaContentRating.EROTICA, MangaContentRating.SAFE)).build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?contentRating[]=erotica&contentRating[]=safe", request)
+        request shouldBeMangaUrl "contentRating[]=erotica&contentRating[]=safe"
     }
 
     @Test
     fun testCreatedAtSince() {
         val builder = MangaList.Builder()
-
         val request = builder.createdAtSince("2022-02-05").build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?createdAtSince=2022-02-05", request)
+        request shouldBeMangaUrl "createdAtSince=2022-02-05"
     }
 
     @Test
     fun testUpdatedAtSince() {
         val builder = MangaList.Builder()
-
         val request = builder.updatedAtSince("2022-02-05").build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?updatedAtSince=2022-02-05", request)
+        request shouldBeMangaUrl "updatedAtSince=2022-02-05"
     }
 
     @Test
     fun testIncludes() {
         val builder = MangaList.Builder()
-
         val request = builder.includes(listOf("test", "test2")).build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?includes[]=test&includes[]=test2", request)
+        request shouldBeMangaUrl "includes[]=test&includes[]=test2"
     }
 
     @Test
     fun testHasAvailableChapters() {
         val builder = MangaList.Builder()
-
         val request = builder.hasAvailableChapters(true).build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?hasAvailableChapters=true", request)
+        request shouldBeMangaUrl "hasAvailableChapters=true"
     }
 
     @Test
     fun testGroup() {
         val builder = MangaList.Builder()
-
         val request = builder.group("Mangaka").build().getRequest()
 
-        assertEquals("https://api.mangadex.org/manga?group=Mangaka", request)
+        request shouldBeMangaUrl "group=Mangaka"
     }
 }

--- a/src/test/kotlin/se/vallett/kdex/utils.kt
+++ b/src/test/kotlin/se/vallett/kdex/utils.kt
@@ -1,0 +1,7 @@
+package se.vallett.kdex
+
+import io.kotest.matchers.shouldBe
+
+internal infix fun String.shouldBeMangaUrl(expected: String) {
+    this shouldBe "https://api.mangadex.org/manga?$expected"
+}


### PR DESCRIPTION
Switch to using [kotest assertions](https://kotest.io/docs/assertions/assertions.html) for assertions, as they're more idiomatic in Kotlin, there's a lot more variations of them, and they produce some nicer messages imo.

Kotest does also provide its own [testing framework](https://kotest.io/docs/framework/framework.html), which runs on the JUnit test engine, but I'm not gonna force one of those testing styles onto here unless you like one of them, as most of them are a pretty drastic departure in style compared to JUnit, unless you're using the [annotation spec.](https://kotest.io/docs/framework/testing-styles.html#annotation-spec)